### PR TITLE
No transparency

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var cssColorNames = require('css-color-names');
 module.exports.ratio = ratio;
 module.exports.score = score;
 module.exports.isAccessible = isAccessible;
+module.exports.isNotTransparent = isNotTransparent;
 
 function ratio(colorOne, colorTwo) {
   colorOne = getRgbTriplet(colorOne);
@@ -38,5 +39,18 @@ function getRgbTriplet(color) {
     color = cssColorNames[color];
   }
 
-  return rgb(color).match(/\((.*)\)/)[1].split(',').slice(0, 3);
+  color = isNotTransparent(color);
+  return color.match(/\((.*)\)/)[1].split(',').slice(0, 3);
+}
+
+function isNotTransparent(color) {
+  // Convert to RGB.
+  color = rgb(color);
+  // Check if the rgb returned color is rgba and if the 'a' value is 0.
+  var cArray = color.match(/\((.*)\)/)[1].split(',');
+  if (cArray.length == 4 && cArray[3] == '0') {
+    throw new TypeError('get-contrast cannot contrast transparent colors');
+  } else {
+    return color;
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -40,3 +40,29 @@ describe('getRgbTriplet', function() {
     assert.throws(contrast.ratio);
   });
 });
+
+describe('isNotTransparent', function() {
+  it('should throw an error when one or more color is transparent', function() {
+    // Several test assertions for different styles of 'transparent'.
+    assert.throws(function() {
+      // Transparent white rgba.
+      contrast.isNotTransparent('rgba(255,255,255,0)');
+    },
+    /get-contrast cannot contrast transparent colors/);
+    // Transparent hsl.
+    assert.throws(function() {
+      contrast.isNotTransparent('hsl(100,100,100,0)');
+    },
+    /get-contrast cannot contrast transparent colors/);
+    // Transparent named color.
+    assert.throws(function() {
+      contrast.isNotTransparent('transparent');
+    },
+    /get-contrast cannot contrast transparent colors/);
+    // Transparent hex.
+    assert.throws(function() {
+      contrast.isNotTransparent('#FFFFFF00');
+    },
+    /get-contrast cannot contrast transparent colors/);
+  });
+});


### PR DESCRIPTION
Throws an error if one of the colors being contrasted is transparent.  
